### PR TITLE
compact the dependencies in case they return no value

### DIFF
--- a/src/dependency_graph.js
+++ b/src/dependency_graph.js
@@ -68,7 +68,7 @@ export default class DependencyGraph {
   }
 
   async styleDependencyLookup() {
-    const styleDependencies = await this.styleDependencies();
+    const styleDependencies = (await this.styleDependencies()).filter(Boolean);
     const styleDependencyNames = styleDependencies.map(pkg => pkg.name);
 
     return styleDependencies.reduce((lookupTable, pkg) => {


### PR DESCRIPTION
In our CI environment, some packages do not return the expected objects, we should compact the dependencies in case they return null or undefined to prevent dr frankenstyle from crashing.