### PR TITLE
Do not crash if there are missing dependencies. Console.error instead

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "loose": "all",
   "stage": 0,
   "optional": ["runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "babel": "5.5.4",
-    "babel-eslint": "3.1.13",
+    "babel-eslint": "^4.0.10",
     "child-process-promise": "^1.1.0",
     "del": "^1.1.1",
     "gulp": "^3.8.11",

--- a/spec/integration_spec.js
+++ b/spec/integration_spec.js
@@ -8,7 +8,7 @@ import {toHaveOrder, toBeAFile} from './helpers/jasmine_matchers';
 import {setup, copyAssets, generateCss} from '../src/dev';
 import cssFilesFromDependencies from '../src/css-files-from-dependencies';
 
-const command = `babel-node ${path.join(__dirname, '..', 'src', 'cli.js')}`;
+const command = `${require.resolve('babel/bin/babel-node')} ${path.join(__dirname, '..', 'src', 'cli.js')}`;
 const expectedPackages = ['tires', 'brakes', 'calipers', 'drums', 'delorean', 'mr-fusion', 'focus', 'f150', 'truck-tires', 'cowboy-hat', 'truck-bed', 'gate', 'timeTravel', '88-mph'];
 const originalWorkingDirectory = process.cwd();
 

--- a/src/dependency_graph.js
+++ b/src/dependency_graph.js
@@ -80,8 +80,10 @@ export default class DependencyGraph {
     const packagesToCheck = [rootPackageJson];
     while (packagesToCheck.length) {
       const pkg = packagesToCheck.shift();
+      if(!pkg) continue;
       for (const dependencyName of Object.keys(Object(pkg.dependencies))) {
         const dependency = installedPackagesLookup[dependencyName];
+        if(!dependency) console.error(`ERROR: missing dependency "${dependencyName}"`);
         if (result.has(dependency)) { continue; }
         result.add(dependency);
         packagesToCheck.push(dependency);
@@ -92,6 +94,7 @@ export default class DependencyGraph {
 
   async styleDependencies() {
     return (await this.dependencies())
+      .filter(Boolean)
       .filter(packageJson => 'style' in packageJson);
   }
 


### PR DESCRIPTION
- Upgrade to babel-eslint was necessary due to changes in gulp-eslint.
- Change to babel-node call in integration spec makes it not require babel global install
- babelrc loose mode is to produce more readable generated code.

Signed-off-by: Charles Hansen <chansen@pivotal.io>